### PR TITLE
Silence spurious warning from press_enter in no-popup test

### DIFF
--- a/test_balsa/test_balsa_gui_std_too_low.py
+++ b/test_balsa/test_balsa_gui_std_too_low.py
@@ -14,7 +14,8 @@ def test_balsa_gui_std_too_low():
     balsa.verbose = False
     balsa.init_logger()
 
-    press_enter_thread = threading.Thread(target=press_enter)
+    # safety net: dismiss the popup if one wrongly appears - but no popup is the expected outcome here
+    press_enter_thread = threading.Thread(target=press_enter, kwargs={"expect_popup": False})
     press_enter_thread.start()
     print("YOU SHOULD NOT SEE ME!!!")  # will be too low of a log level and not do anything
     popup_present = is_popup_dialog_with_ok()

--- a/test_balsa/tst_balsa.py
+++ b/test_balsa/tst_balsa.py
@@ -49,7 +49,12 @@ class TstGUIBalsa(TstBalsa):
         super().__init__(name, gui=True, is_root=is_root, rate_limits=rate_limits)
 
 
-def press_enter(n: int = 1, enter_press_time: float = 1.0):
+def press_enter(n: int = 1, enter_press_time: float = 1.0, expect_popup: bool = True):
+    """
+    Wait for a popup dialog and dismiss it with Enter key presses. Pass expect_popup=False from tests that verify no popup appears - a missing popup is then the
+    expected outcome, so return quietly instead of pytest.fail()-ing (which in this worker thread can't fail the test anyway - it just surfaces as a
+    PytestUnhandledThreadExceptionWarning). A popup that wrongly shows up is still dismissed so it doesn't linger; the test's own assertion reports the failure.
+    """
     found = False
     count = 0
     while not found and count < 10:
@@ -57,7 +62,9 @@ def press_enter(n: int = 1, enter_press_time: float = 1.0):
         time.sleep(1.0)
         count += 1
     if not found:
-        pytest.fail("press_enter: popup dialog not found")
+        if expect_popup:
+            pytest.fail("press_enter: popup dialog not found")
+        return
     for i in range(n):
         time.sleep(enter_press_time)
         pyautogui.press("enter")


### PR DESCRIPTION
## Problem

Every full-suite run emitted a `PytestUnhandledThreadExceptionWarning` from `test_balsa_gui_std_too_low`. That test verifies a stray `print()` in a non-verbose GUI app does **not** pop up a dialog, but its `press_enter` safety-net thread reused the popup-expecting helper behavior: after ~10 s of not finding a dialog — the test's *success* condition — it called `pytest.fail("press_enter: popup dialog not found")`. In a worker thread that can't fail the test; pytest just converts it into the warning.

## Change

`press_enter` gains an `expect_popup: bool = True` parameter. With `expect_popup=False` (now passed by `test_balsa_gui_std_too_low`), a missing popup returns quietly. A popup that wrongly appears is still dismissed so it doesn't linger on screen — the test's own `is_popup_dialog_with_ok()` assertion reports that failure.

Behavior of all popup-expecting tests is unchanged (default remains `expect_popup=True`).

## Verification

Ran the four dialog-related GUI tests with `-W error::pytest.PytestUnhandledThreadExceptionWarning` so any recurrence would fail loudly: 4 passed, no warning. black/flake8/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)